### PR TITLE
Update ﻿_TorchAwsNeuronXLABackend to enable neuron_parallel_compile

### DIFF
--- a/python/ray/_private/accelerators/neuron.py
+++ b/python/ray/_private/accelerators/neuron.py
@@ -108,6 +108,9 @@ class NeuronAcceleratorManager(AcceleratorManager):
         if os.environ.get(NOSET_AWS_NEURON_RT_VISIBLE_CORES_ENV_VAR):
             return
 
+        if not os.environ.get(NeuronAcceleratorManager.get_visible_accelerator_ids_env_var()):
+            return
+
         os.environ[
             NeuronAcceleratorManager.get_visible_accelerator_ids_env_var()
         ] = ",".join([str(i) for i in visible_neuron_core_ids])

--- a/python/ray/train/torch/xla/config.py
+++ b/python/ray/train/torch/xla/config.py
@@ -3,6 +3,7 @@ import uuid
 from dataclasses import dataclass
 import re
 import shutil
+import logging
 
 import ray
 from ray.train._internal.utils import get_address_and_port
@@ -10,6 +11,8 @@ from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import Backend
 from ray.train.torch import TorchConfig
 from ray.util import PublicAPI
+
+logger = logging.getLogger(__name__)
 
 
 @PublicAPI(stability="alpha")
@@ -92,10 +95,10 @@ def _neuron_compile_extracted_graphs():
 
     # Only 1 worker per node should run parallel_compile()
     if os.environ.get("LOCAL_RANK") == "0":
-        print("Compiling extracted graphs on local rank0 worker")
+        logger.info("Compiling extracted graphs on local rank0 worker")
 
         parallel_compile_workdir = (
-            f"/var/tmp/{os.environ.get('USER','no-user')}_parallel_compile_workdir/"
+            f"/tmp/{os.environ.get('USER','no-user')}/parallel_compile_workdir/"
         )
         if os.path.exists(parallel_compile_workdir):
             shutil.rmtree(parallel_compile_workdir)
@@ -138,7 +141,7 @@ class _TorchAwsNeuronXLABackend(Backend):
 
         # Set up env vars for neuron parallel compilation graph extraction
         if backend_config.neuron_parallel_compile:
-            print("Extracting graphs for Neuron parallel compilation")
+            logger.info("Extracting graphs for Neuron parallel compilation")
             worker_group.execute(_set_neuron_parallel_compile_env_vars)
 
     def on_training_start(

--- a/python/ray/train/torch/xla/config.py
+++ b/python/ray/train/torch/xla/config.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 from dataclasses import dataclass
+import re
 
 import ray
 from ray.train._internal.utils import get_address_and_port
@@ -19,6 +20,8 @@ class TorchXLAConfig(TorchConfig):
     Currently, only "neuron_cores" accelerator (AwsNeuronXLABackend)
     is supported with xrt runtime.
     """
+
+    neuron_parallel_compile: bool = False
 
     @property
     def backend_cls(self):
@@ -68,6 +71,46 @@ def _setup_xla_torch_process_group():
         raise ImportError("torch_xla must be installed to use torch_xla backend.")
 
 
+# The following env vars enable Neuron graph extraction for parallel compilation
+#   Note: model outputs are invalid and should be ignored while these env vars are set
+def _set_neuron_parallel_compile_env_vars():
+    os.environ["NEURON_PARALLEL_COMPILE"] = "1"
+    os.environ["NEURON_EXTRACT_GRAPHS_ONLY"] = "1"
+    os.environ["NEURON_FALL_BACK_TO_NULL_NEFF"] = "1"
+
+
+# Compile previously extracted Neuron graphs
+def _neuron_compile_extracted_graphs():
+    try:
+        from libneuronxla.neuron_parallel_compile import parallel_compile
+        from libneuronxla.neuron_cc_cache import CacheUrl
+    except ImportError:
+        raise ImportError(
+            "libneuronxla must be installed to use Neuron parallel compilation."
+        )
+
+    # Only 1 worker per node should run parallel_compile()
+    if os.environ.get("LOCAL_RANK") == "0":
+        print("Compiling extracted graphs on local rank0 worker")
+
+        parallel_compile_workdir = (
+            f"/var/tmp/{os.environ.get('USER','no-user')}_parallel_compile_workdir/"
+        )
+        os.makedirs(parallel_compile_workdir, exist_ok=True)
+
+        # Users can set the cache directory using --cache_dir in NEURON_CC_FLAGS or by
+        # using NEURON_COMPILE_CACHE_URL. --cache_dir takes precedence.
+        explicit_cache_dir = None
+        if neuron_cc_flags := os.environ.get("NEURON_CC_FLAGS"):
+            if s := re.search(r"--cache_dir[= ](\S+)", neuron_cc_flags):
+                explicit_cache_dir = s.group(1)
+
+        parallel_compile(
+            parallel_compile_workdir,
+            CacheUrl.get_cache_url(explicit_cache_dir),
+        )
+
+
 class _TorchAwsNeuronXLABackend(Backend):
     unique_run_id: str = str(uuid.uuid4())
 
@@ -90,6 +133,11 @@ class _TorchAwsNeuronXLABackend(Backend):
         # Set the env vars on all workers.
         worker_group.execute(set_env_vars, addr=master_addr, port=master_port)
 
+        # Set up env vars for neuron parallel compilation graph extraction
+        if backend_config.neuron_parallel_compile:
+            print("Extracting graphs for Neuron parallel compilation")
+            worker_group.execute(_set_neuron_parallel_compile_env_vars)
+
     def on_training_start(
         self, worker_group: WorkerGroup, backend_config: TorchXLAConfig
     ):
@@ -105,6 +153,11 @@ class _TorchAwsNeuronXLABackend(Backend):
     def on_shutdown(self, worker_group: WorkerGroup, backend_config: TorchXLAConfig):
         """
         Logic ran right after training is finished.
-        This is a sanity cleanup to kill xrt server.
+        This is a sanity cleanup to kill xrt server, and to optionally
+        run neuron parallel graph compilation
         """
         worker_group.execute(_kill_xrt_server)
+
+        # Compile the extracted graphs. This must run at end of training.
+        if backend_config.neuron_parallel_compile:
+            worker_group.execute(_neuron_compile_extracted_graphs)

--- a/python/ray/train/torch/xla/config.py
+++ b/python/ray/train/torch/xla/config.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from dataclasses import dataclass
 import re
+import shutil
 
 import ray
 from ray.train._internal.utils import get_address_and_port
@@ -96,6 +97,8 @@ def _neuron_compile_extracted_graphs():
         parallel_compile_workdir = (
             f"/var/tmp/{os.environ.get('USER','no-user')}_parallel_compile_workdir/"
         )
+        if os.path.exists(parallel_compile_workdir):
+            shutil.rmtree(parallel_compile_workdir)
         os.makedirs(parallel_compile_workdir, exist_ok=True)
 
         # Users can set the cache directory using --cache_dir in NEURON_CC_FLAGS or by


### PR DESCRIPTION
For larger models that use TP/PP we need to precompile the model graphs and stage the compiled graphs in the Neuron cache.

This precompilation is usually achieved using the neuron_parallel_compile wrapper included with the Neuron SDK. This wrapper cannot be directly invoked using Ray Train. Instead, the included changes allow graph extraction and compilation to be enabled by setting `neuron_parallel_compile=True` when creating the TorchXLAConfig(), ex:
```
    trainer = TorchTrainer(
        train_loop_per_worker=train_func,
        train_loop_config=args,
        torch_config=TorchXLAConfig(neuron_parallel_compile=True),
        scaling_config=ScalingConfig(
            num_workers=args.num_nodes * 32, resources_per_worker={"neuron_cores": 1}
        ),
    )
```

Training flow would then be:
* Run a short training job (ex: <100 steps) with `neuron_parallel_compile=True` to populate the cache
* Run a full training job with `neuron_parallel_compile=False` (the default) which will use the cached graphs

This has been tested using 4-node allreduce and 4-node llama2-7B training. The llama2-7B example will be published at a later date.